### PR TITLE
Add matching and handling of quoted values

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -76,7 +76,9 @@ module.exports = function (env_file, options) {
         var key_value = line.split(/\s*\=\s*/);
 
         var env_key = key_value[0];
-        var env_value = key_value[1];
+        
+        // remove ' and " characters if right side of = is quoted
+        var env_value = key_value[1].match(/^(['"]?)([^\n]*)\1$/m)[2];
 
         // overwrite already defined `process.env.*` values?
         if (!!options.overwrite) {


### PR DESCRIPTION
If .env var value is quoted. eg. KEY='some value' 
Previously, matched value retained ' or " characters. This commit removes ' and " characters if they are present
