### PR TITLE
parse out more shell comments

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -56,10 +56,11 @@ module.exports = function (env_file, options) {
   }
 
   if (fs.existsSync(env_file)) {
+    var file_contents;
     var lines;
 
     try {
-      lines = fs.readFileSync(env_file, 'utf8').match(/([\w+]+)\s*\=\s*(.*)/gmi) || [];
+      file_contents = fs.readFileSync(env_file, 'utf8');
     } catch (err) {
       if (options.raise) {
         throw new TypeError("Environment file could not be read: " + err);
@@ -71,14 +72,28 @@ module.exports = function (env_file, options) {
       }
     }
 
+    lines = file_contents.split('\n');
     lines.forEach(function(line) {
-      if (!/\#/i.test(line)) { // ignore comment lines (starting with #).
+      if (!/^\s*#/.test(line)) { // ignore comment lines (starting with #).
+
+        // trim whitespace and exports
+        line = line.replace(/^(\s*exports)?\s+|\s+$/, '');
+
+        // remove trailing comments (naive of full shell quoting abilities)
+        line = line.replace(/\s*#[^"]*$/,'');
+
         var key_value = line.split(/\s*\=\s*/);
 
+        if (!key_value || key_value.length !== 2) {
+          // haven't found a key-value pair
+          return;
+        }
+
         var env_key = key_value[0];
-        
-        // remove ' and " characters if right side of = is quoted
-        var env_value = key_value[1].match(/^(['"]?)([^\n]*)\1$/m)[2];
+        var env_value = key_value[1];
+
+        // unwrap any quotes
+        env_value = env_value.replace(/^(['"]?)([^\n]*)\1$/, '$2');
 
         // overwrite already defined `process.env.*` values?
         if (!!options.overwrite) {

--- a/test/fixtures/.env.2
+++ b/test/fixtures/.env.2
@@ -2,3 +2,15 @@
 
 FOO=1
 BAR=bar
+
+#BAZ=baz # intentionally commented out: should be ignored
+
+# intentional trailing whitespace: should be ignored
+QUUX=quux   
+
+# intentional space in value: will be tested
+QUUUX="qu u ux"
+
+QUUUUX=quuuux # intentional trailing comment: should be ignored
+
+QUUUUUX="quuuuux" # intentional trailing comment after quotes: should be ignored

--- a/test/index.js
+++ b/test/index.js
@@ -142,6 +142,11 @@ module.exports = {
       expect(process.env.BAZ).to.be.equal(undefined);
       expect(process.env.QUX).to.be.equal(undefined);
 
+      expect(process.env.QUUX).to.be.equal('quux');
+      expect(process.env.QUUUX).to.be.equal('qu u ux');
+      expect(process.env.QUUUUX).to.be.equal('quuuux');
+      expect(process.env.QUUUUUX).to.be.equal('quuuuux');
+
       process.env.FOO = 'foo2';
 
       expect(function() {


### PR DESCRIPTION
node-env-file assigns variables that have been commented out like `BAZ` is here:

```
FOO=1
#BAR=2
BAZ=3
```

When poking around I found there were some other ways I sometimes add comments to env files which would be parsed oddly. I've added those as new examples to the test suite.

(This parsing is nowhere near comprehensive; the mixture of quoting and commenting is beyond regular expressions AFAIK. But I believe this works for common cases with double-quotes.)

Spaces in a quoted value would make it hiccup as well, fixed and tested here.
