### PR TITLE
Support more flexible name/values

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -73,12 +73,12 @@ module.exports = function (env_file, options) {
 
     lines.forEach(function(line) {
       if (!/\#/i.test(line)) { // ignore comment lines (starting with #).
-        var key_value = line.split(/\s*\=\s*/);
-
-        var env_key = key_value[0];
+        var key_value = line.match(/^([^=]+)\s*=\s*(.+)$/);
         
+        var env_key = key_value[1];
+
         // remove ' and " characters if right side of = is quoted
-        var env_value = key_value[1].match(/^(['"]?)([^\n]*)\1$/m)[2];
+        var env_value = key_value[2].match(/^(['"]?)([^\n]*)\1$/m)[2];
 
         // overwrite already defined `process.env.*` values?
         if (!!options.overwrite) {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "node-env-file",
   "description": "Parse and load environment files (containing ENV variable exports) into Node.js environment, i.e. `process.env`.",
   "keywords": ["process", "env", "file", "files", ".env", "ENV", "process.env", "parse", "load", "export", "exports"],
-  "version": "0.1.0",
+  "version": "0.1.1",
   "homepage": "https://github.com/grimen/node-env-file",
   "repository": {
     "type": "git",

--- a/test/fixtures/.env.3
+++ b/test/fixtures/.env.3
@@ -1,0 +1,3 @@
+# ignore this and blank lines
+
+FOO=http://foo.com?bar=baz

--- a/test/fixtures/.env.exports.3
+++ b/test/fixtures/.env.exports.3
@@ -1,0 +1,3 @@
+# ignore this and blank lines
+
+exports FOO=http://foo.com?bar=baz

--- a/test/index.js
+++ b/test/index.js
@@ -165,6 +165,14 @@ module.exports = {
       expect(process.env.QUX).to.be.equal(undefined);
     },
 
+    '("./fixtures/.env.3")': function () {
+      expect(function() {
+        env(__dirname + '/fixtures/.env.3');
+      }).to.not.throw(Error);
+
+      expect(process.env.FOO).to.be.equal('http://foo.com?bar=baz');
+    },
+
     '("./fixtures/.env.exports.0")': function () {
       expect(function() {
         env(__dirname + '/fixtures/.env.exports.0');
@@ -262,7 +270,15 @@ module.exports = {
       expect(process.env.BAR).to.be.equal('bar');
       expect(process.env.BAZ).to.be.equal(undefined);
       expect(process.env.QUX).to.be.equal(undefined);
-    }
+    },
+
+    '("./fixtures/.env.exports.3")': function () {
+      expect(function() {
+        env(__dirname + '/fixtures/.env.exports.3');
+      }).to.not.throw(Error);
+
+      expect(process.env.FOO).to.be.equal('http://foo.com?bar=baz');
+    }    
   }
 
 };


### PR DESCRIPTION
I ran into an issue where env values with URL's that contained equal signs (ex: http://foo.com?bar=baz) were not parsing correctly.  I've replaced the string split with a more flexible regex match.  Tests have also been updated.
