### PR TITLE
allow empty value QUX=

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ tmp/*
 log/*
 node_modules
 npm-debug.log
+.idea/

--- a/lib/index.js
+++ b/lib/index.js
@@ -73,7 +73,7 @@ module.exports = function (env_file, options) {
 
     lines.forEach(function(line) {
       if (!/^\s*\#/i.test(line)) { // ignore comment lines (starting with #).
-        var key_value = line.match(/^([^=]+)\s*=\s*(.+)$/);
+        var key_value = line.match(/^([^=]+)\s*=\s*(.*)$/);
 
         var env_key = key_value[1];
 

--- a/test/fixtures/.env.2
+++ b/test/fixtures/.env.2
@@ -2,3 +2,4 @@
 
 FOO=1
 BAR=bar
+QUX=

--- a/test/fixtures/.env.exports.2
+++ b/test/fixtures/.env.exports.2
@@ -2,3 +2,4 @@
 
 exports FOO=1
 exports BAR=bar
+exports QUX=

--- a/test/index.js
+++ b/test/index.js
@@ -140,7 +140,7 @@ module.exports = {
       expect(process.env.FOO).to.be.equal('1');
       expect(process.env.BAR).to.be.equal('bar');
       expect(process.env.BAZ).to.be.equal(undefined);
-      expect(process.env.QUX).to.be.equal(undefined);
+      expect(process.env.QUX).to.be.equal('');
 
       process.env.FOO = 'foo2';
 
@@ -151,7 +151,7 @@ module.exports = {
       expect(process.env.FOO).to.be.equal('foo2');
       expect(process.env.BAR).to.be.equal('bar');
       expect(process.env.BAZ).to.be.equal(undefined);
-      expect(process.env.QUX).to.be.equal(undefined);
+      expect(process.env.QUX).to.be.equal('');
 
       process.env.FOO = 'foo2';
 
@@ -162,7 +162,7 @@ module.exports = {
       expect(process.env.FOO).to.be.equal('1');
       expect(process.env.BAR).to.be.equal('bar');
       expect(process.env.BAZ).to.be.equal(undefined);
-      expect(process.env.QUX).to.be.equal(undefined);
+      expect(process.env.QUX).to.be.equal('');
     },
 
     '("./fixtures/.env.3")': function () {
@@ -255,7 +255,7 @@ module.exports = {
       expect(process.env.FOO).to.be.equal('1');
       expect(process.env.BAR).to.be.equal('bar');
       expect(process.env.BAZ).to.be.equal(undefined);
-      expect(process.env.QUX).to.be.equal(undefined);
+      expect(process.env.QUX).to.be.equal('');
 
       process.env.FOO = 'foo2';
 
@@ -266,7 +266,7 @@ module.exports = {
       expect(process.env.FOO).to.be.equal('foo2');
       expect(process.env.BAR).to.be.equal('bar');
       expect(process.env.BAZ).to.be.equal(undefined);
-      expect(process.env.QUX).to.be.equal(undefined);
+      expect(process.env.QUX).to.be.equal('');
 
       process.env.FOO = 'foo2';
 
@@ -277,7 +277,7 @@ module.exports = {
       expect(process.env.FOO).to.be.equal('1');
       expect(process.env.BAR).to.be.equal('bar');
       expect(process.env.BAZ).to.be.equal(undefined);
-      expect(process.env.QUX).to.be.equal(undefined);
+      expect(process.env.QUX).to.be.equal('');
     },
 
     '("./fixtures/.env.exports.3")': function () {


### PR DESCRIPTION
Updated regex to support empty value in key/value combo. Current implementation throws -TypeError: Cannot read property '1' of null for QUX=
