### PR TITLE
Moved unnecessary deps to dev-dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,12 +47,12 @@
     "node": ">= 0.8.0"
   },
   "dependencies": {
-    "glob": "~3.2.0",
-    "temp": "~0.8.0"
   },
   "devDependencies": {
     "mocha": "latest",
     "chai": "latest",
-    "cover": "latest"
+    "cover": "latest",
+    "glob": "~3.2.0",
+    "temp": "~0.8.0"
   }
 }


### PR DESCRIPTION
Saw some strange deps when upgrading from 0.1.4 to 0.1.7.
They seem only to be used in testing. Moved from deps to dev-deps in package.json.